### PR TITLE
fix(pages): removes errant property that was missed.

### DIFF
--- a/pages/blog/search.js
+++ b/pages/blog/search.js
@@ -42,7 +42,7 @@ export default function BlogSearch(props) {
           onChange={onSearch}
           placeholder="Search"
           type="text"
-          value={searchValue.value}
+          value={searchValue}
         />
         {pageContent.body && (
           <PageContentWrapper>
@@ -53,7 +53,7 @@ export default function BlogSearch(props) {
           <PostList posts={results} />
         ) : (
           <div>
-            <h1>No posts found for search: {searchValue.value}</h1>
+            <h1>No posts found for search: {searchValue}</h1>
             <button onClick={onReset}>Clear Search</button>
           </div>
         )}


### PR DESCRIPTION
## What does this PR do?

The test suite did not catch this because it was using the correct values. In the `/blog/search` page I was sill using `searchValue.value` meaning the code expected `searchValue` to be an object with the property `value` however it was receiving a string and in turn the `<input />` and printed value were never showing in the DOM.
