### PR TITLE
fix(pages): fixes problem with `blog/tag/[tag]` routing layer and data fetching

### DIFF
--- a/components/Post/Tags/index.js
+++ b/components/Post/Tags/index.js
@@ -2,7 +2,6 @@ import TagsStyles from "@styles/Tags.module.css";
 
 export default function Tags(props) {
   const { tags } = props;
-  console.log(props);
 
   return (
     <ul className={TagsStyles.tags}>

--- a/components/RecentPostList/index.js
+++ b/components/RecentPostList/index.js
@@ -11,8 +11,6 @@ import ReactMarkdownRenderers from "@utils/ReactMarkdownRenderers";
 
 export default function RecentPostList(props) {
   const { posts } = props;
-  console.log(props);
-  //console.log(post.contentfulMetadata.tags);
 
   return (
     <>
@@ -31,23 +29,25 @@ export default function RecentPostList(props) {
                   </h2>
                 </a>
               </Link>
-              
+
               <div className={ContentListStyles.contentList__excerpt}>
                 <ReactMarkdown
                   children={post.excerpt}
                   renderers={ReactMarkdownRenderers(post.excerpt)}
                 />
               </div>
-          
-              <div>
-              <Image
-                src={post.image.url}
-                width="1200"
-                height="400"
-                layout="responsive"/>
 
+              <div>
+                <Image
+                  src={post.image.url}
+                  width="1200"
+                  height="400"
+                  layout="responsive"
+                />
               </div>
-              {post.contentfulMetadata.tags !== null && <Tags tags={post.contentfulMetadata.tags} />}
+              {post.contentfulMetadata.tags !== null && (
+                <Tags tags={post.contentfulMetadata.tags} />
+              )}
             </article>
           </li>
         ))}

--- a/pages/blog/tag/[tag].js
+++ b/pages/blog/tag/[tag].js
@@ -24,10 +24,11 @@ export default function PostWrapper(props) {
 }
 
 export async function getStaticPaths() {
+  // Array<string>
   const blogPostSlugs = await ContentfulApi.getAllUniquePostTags();
 
-  const paths = blogPostSlugs.map((tags) => {
-    return { params: { tags } };
+  const paths = blogPostSlugs.map((tag) => {
+    return { params: { tag } };
   });
 
   // Using fallback: "blocking" here enables preview mode for unpublished blog slugs
@@ -39,7 +40,10 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params, preview = false }) {
-  const post = await ContentfulApi.getPostBySlug(params.slug, {
+  console.log("====================================");
+  console.log("params", params);
+  console.log("====================================");
+  const post = await ContentfulApi.getPostBySlug(params.tag, {
     preview: preview,
   });
 

--- a/pages/blog/tag/[tag].js
+++ b/pages/blog/tag/[tag].js
@@ -40,9 +40,6 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params, preview = false }) {
-  console.log("====================================");
-  console.log("params", params);
-  console.log("====================================");
   const post = await ContentfulApi.getPostBySlug(params.tag, {
     preview: preview,
   });

--- a/utils/ContentfulApi.js
+++ b/utils/ContentfulApi.js
@@ -188,8 +188,6 @@ export default class ContentfulApi {
     return returnSlugs;
   }
 
-
-
   /**
    * Fetch all unique blog posts tags.
    *
@@ -198,34 +196,32 @@ export default class ContentfulApi {
    * and returns them in one array.
    *
    * The array is then filtered for unique values.
-   * 
+   *
    * For more information about GraphQL query complexity, visit:
    * https://www.contentful.com/developers/videos/learn-graphql/#graphql-fragments-and-query-complexity
    *
    */
 
-
-   static async getAllUniquePostTags() {
+  static async getAllUniquePostTags() {
     let page = 1;
     let shouldQueryMoreTags = true;
-    const returnTags = [];
+    let returnTags = [];
 
     while (shouldQueryMoreTags) {
-      const response = await this.getPaginatedSlugs(page);
+      const { slugs, total } = await this.getPaginatedSlugs(page);
 
-      if (response.contentfulMetadata.length > 0) {
-        returnTags.push(...response.contentfulMetadata.tags.id);
+      // slugs: Array<string>
+      if (slugs.length > 0) {
+        returnTags = [...returnTags, ...slugs];
       }
 
-      shouldQueryMoreTags = returnTags.length < response.total;
+      shouldQueryMoreTags = returnTags.length < total;
       page++;
     }
-
+    // Array<string>
+    console.log("getAllUniquePostTags", returnTags);
     return returnTags;
   }
-
-
-
 
   /**
    * Fetch a batch of blog posts (by given page number).
@@ -379,12 +375,6 @@ export default class ContentfulApi {
     return returnPosts;
   }
 
-
-
-
-
-
-
   /**
    * Fetch a single blog post by slug.
    *
@@ -439,7 +429,7 @@ export default class ContentfulApi {
           title
           slug
           excerpt
-          
+
           externalUrl
           author {
             name
@@ -566,7 +556,7 @@ export default class ContentfulApi {
             title
             slug
             excerpt
-            
+
           }
         }
       }`;
@@ -617,8 +607,8 @@ export default class ContentfulApi {
           title
           slug
           excerpt
-        
-         
+
+
         }
       }
     }`;
@@ -628,7 +618,6 @@ export default class ContentfulApi {
     const recentPosts = response.data.blogPostCollection.items
       ? response.data.blogPostCollection.items
       : [];
-    //console.log(recentPosts);
     return recentPosts;
   }
 

--- a/utils/ContentfulApi.js
+++ b/utils/ContentfulApi.js
@@ -218,8 +218,6 @@ export default class ContentfulApi {
       shouldQueryMoreTags = returnTags.length < total;
       page++;
     }
-    // Array<string>
-    console.log("getAllUniquePostTags", returnTags);
     return returnTags;
   }
 


### PR DESCRIPTION
## What does this PR do?

CC @jazzybuilds 

- Renames `pages/blog/tag/[slug].js` to `pages/blog/tag/[tag].js`
- Fixes internals of `getAllUniquePostTags`
- Removes errant `console.logs`
- Makes changes to `getStaticPaths` and `getStaticProps`

## Things to note

When working with dynamic pages in `next` if we have a path such as `pages/blog/tag/[slug].js` then `slug` is the expected query parameter that `nextRouter` will be looking for upon navigation. The code had `getStaticPaths` creating the possible routing paths as `{ params: { tags }` which would never route a user to the `/tag/[slug]` page.

The internals of the `getAllUniquePostTags` were incorrect. That's why the error message:

> Cannot find property 'length' of undefined

was appearing. On quick inspection I found the request only returns `slugs` and `total`. `slugs` is an `Array<string>` which I don't believe matches the data structure you had constructed for tags so that might be worth looking into. I was pretty sure you had created a data structure for a `tag` as the below:

```typescript
type Tag = {
  id: string
  name: string
}
```